### PR TITLE
DDCE-458: Continue button disabled on /upload-a-file

### DIFF
--- a/.github/PULL_REQUEST_TEMLATE.md
+++ b/.github/PULL_REQUEST_TEMLATE.md
@@ -1,0 +1,30 @@
+# DDCE-(StoryNumberHere)
+
+##Bug fix / New feature (delete as appropriate)
+
+Please include a summary / description of the change and which issue it fixes.  Include any relevant user needs, context or links to other PRs related to this PR (eg. acceptance tests, environment config).
+
+## PR Suggestions
+- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
+- Have you done a visual check of the changes?
+- Is there still any commented or unused code? Lingering printlns?
+- Have things been implemented in a complicated way?
+- Are the tests still over the coverage threshold?
+- Does the compiler throw a lot of warnings? 
+- Have methods and tests been named clearly?
+- Were there any changes in the config? Do changes need to be made in app-config-???
+
+
+## Checklist PR Raiser
+ - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
+ - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
+ - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
+ - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
+ - [ ]  I've run a dependency check to ensure all dependencies are up to date
+
+## Checklist PR Reviewer
+ - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
+ - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
+ - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
+ - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
+ - [ ]  I've run a dependency check to ensure all dependencies are up to date

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 
 !.gitignore
+!.github
 
 .cache
 /.classpath

--- a/app/views/file_upload.scala.html
+++ b/app/views/file_upload.scala.html
@@ -61,7 +61,7 @@
 
                 <input id="choose-file" name="file" type="file" size="40" data-journey-click="button - click:Upload a file:Choose file"/>
                 <p class="ras-bottom-margin"><a href="http://www.gov.uk/guidance/find-the-relief-at-source-residency-statuses-of-multiple-members" target="_blank" id="upload-help-link" data-journey-click="link - click:Upload a file:Get help formatting your file">@messages("get.help.uploading.link")</a></p>
-                <button class="button" type="submit" id="continue" data-journey-click="button - click:Upload a file:Continue">@messages("continue")</button>
+                <button class="button" type="submit" id="continue" data-journey-click="button - click:Upload a file:Continue" data-ignore-double-submit="true">@messages("continue")</button>
             </form>
         </div>
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,11 +18,11 @@ object AppDependencies {
     "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-25",
     "org.scalatest" %% "scalatest" % "3.0.8",
     "org.pegdown" % "pegdown" % "1.6.0",
-    "org.jsoup" % "jsoup" % "1.12.1",
+    "org.jsoup" % "jsoup" % "1.12.2",
     "com.typesafe.play" %% "play-test" % PlayVersion.current,
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1",
     "org.mockito" % "mockito-core" % "3.3.3",
-    "org.scalacheck" %% "scalacheck" % "1.14.1",
+    "org.scalacheck" %% "scalacheck" % "1.14.3",
 		"uk.gov.hmrc" %% "domain" % "5.6.0-play-25"
 	).map(_ % "test")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")


### PR DESCRIPTION
Added data-ignore-double-submit="true" tag to the submit button to prevent the button from being disabled after attempting to upload an incorrect file type.

Also added the PR template and dependency checker