### PR TITLE
DDCE-458: Continue button on /upload-a-file no longer gets disabled 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-!.github
+.*
 
 !.gitignore
+!.github
 
 .cache
 /.classpath

--- a/app/views/file_upload.scala.html
+++ b/app/views/file_upload.scala.html
@@ -61,7 +61,7 @@
 
                 <input id="choose-file" name="file" type="file" size="40" data-journey-click="button - click:Upload a file:Choose file"/>
                 <p class="ras-bottom-margin"><a href="http://www.gov.uk/guidance/find-the-relief-at-source-residency-statuses-of-multiple-members" target="_blank" id="upload-help-link" data-journey-click="link - click:Upload a file:Get help formatting your file">@messages("get.help.uploading.link")</a></p>
-                <button class="button" type="submit" id="continue" data-journey-click="button - click:Upload a file:Continue">@messages("continue")</button>
+                <button class="button" type="submit" id="continue" data-journey-click="button - click:Upload a file:Continue" data-ignore-double-submit="true">@messages("continue")</button>
             </form>
         </div>
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,11 +18,11 @@ object AppDependencies {
     "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-25",
     "org.scalatest" %% "scalatest" % "3.0.8",
     "org.pegdown" % "pegdown" % "1.6.0",
-    "org.jsoup" % "jsoup" % "1.12.1",
+    "org.jsoup" % "jsoup" % "1.12.2",
     "com.typesafe.play" %% "play-test" % PlayVersion.current,
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1",
     "org.mockito" % "mockito-core" % "3.3.3",
-    "org.scalacheck" %% "scalacheck" % "1.14.1",
+    "org.scalacheck" %% "scalacheck" % "1.14.3",
 		"uk.gov.hmrc" %% "domain" % "5.6.0-play-25"
 	).map(_ % "test")
 


### PR DESCRIPTION
# DDCE-(458)

##Bug fix
Added "data-ignore-double-submit='true'" to form submit button so that it would no longer be disabled (requiring a page refresh to fix) after a failed submission.

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
