### PR TITLE
[RS][DDCE-672] Resolving Welsh timeout dialog issue.

### DIFF
--- a/app/views/ras_main.scala.html
+++ b/app/views/ras_main.scala.html
@@ -57,12 +57,16 @@
                 countdown: @appConfig.timeOutCountDownSeconds,
                 keep_alive_url: '@controllers.routes.SessionController.keepAlive',
                 title: "@Messages("ras.timeoutDialog.title")",
-                messageSeconds: "@Messages("ras.timeoutDialog.seconds")",
-                messageMinutes: "@Messages("ras.timeoutDialog.minutes")",
-                messageMinute: "@Messages("ras.timeoutDialog.minute")",
                 logout_url: "@appConfig.signOutUrl",
                 message: "@Messages("ras.timeoutDialog.p1")",
                 keep_alive_button_text: "@Messages("ras.timeoutDialog.button")",
+                sign_out_button_text: "@Messages("ras.timeoutDialog.signout")",
+                properties: {
+                    seconds: "@Messages("ras.timeoutDialog.seconds")",
+                    second: "@Messages("ras.timeoutDialog.second")",
+                    minutes: "@Messages("ras.timeoutDialog.minutes")",
+                    minute: "@Messages("ras.timeoutDialog.minute")"
+                    }
       });
     }
     </script>

--- a/conf/messages
+++ b/conf/messages
@@ -173,11 +173,13 @@ label.thanks_for_your_feedback=Thanks for your feedback
 ##timeoutDialog
 
 ras.timeoutDialog.title= You are about to be signed out
+ras.timeoutDialog.second= second
 ras.timeoutDialog.seconds= seconds
 ras.timeoutDialog.minutes= minutes
 ras.timeoutDialog.minute= minute
 ras.timeoutDialog.button= Stay signed in
 ras.timeoutDialog.p1 = For security reasons, you will be signed out of this service in:
+ras.timeoutDialog.signout= Sign out
 
 ###### WDYWTDP ######################################################################################
 


### PR DESCRIPTION
# DDCE-672

## Bug fix

It was discovered that although RAS isn't Welsh-translated, it wasn't correctly overriding the default assets messages; thus, if the PLAY_LANG cookie was set to cy (due to e.g. a different service being open in Welsh on another tab), some of the timeoutDialog messages were taken as the assets-frontend defaults in Welsh. This was resolved by ensuring all the messages are taken straight from the ras-frontend's messages file.
Those messages that weren't already in the messages file (second and sign-out messages) were taken from assets-frontend.

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???
- Have you done a manual walkthrough?


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
## Checklist PR Reviewer
 - [x]  I've verified every effort was made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've verified appropriate tests were included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've verified commits were squashed and rebased - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
