### PR TITLE
[DP][DDCE-1446]: Re-order date of birth page for accessibility

### DIFF
--- a/app/views/member_dob.scala.html
+++ b/app/views/member_dob.scala.html
@@ -17,7 +17,7 @@
 @import config.ApplicationConfig
 @(memberDobForm: Form[models.MemberDateOfBirth], name:String, edit: Boolean)(implicit request: Request[_], messages: Messages, appConfig: ApplicationConfig)
 
-@import uk.gov.hmrc.play.views.html.helpers.{errorSummary, form, dateFieldsFreeInlineLegend}
+@import uk.gov.hmrc.play.views.html.helpers.{errorSummary, form, input}
 
 @ras_main(title = messages("member.dob.page.title")) {
 
@@ -27,20 +27,50 @@
 @(if(memberDobForm.hasErrors) errorSummary(Messages("generic.errors_heading"), memberDobForm))
 
 @form(action = routes.MemberDOBController.post(edit)) {
+<div class ='@{if(memberDobForm.hasErrors) "form-field--error"}'>
 
-<fieldset class="inline">
+<fieldset class='inline form-date form-group' aria-describedby="dob-hint">
     <legend>
         <header class="page-header">
             <h1 id="header" class="heading-xlarge">@messages("member.dob.page.header",name)</h1>
         </header>
     </legend>
 
+    <div id="dob-hint" class="form-hint">@Messages("dob.hint")</div>
 
-    @dateFieldsFreeInlineLegend(memberDobForm,
-    "dateOfBirth",
-    '_inputHint -> Messages("dob.hint")
+    @memberDobForm.errors.map { error => <span class="error-notification">@Messages(error.message, error.args: _*)</span>}
+    @input(
+    memberDobForm("dateOfBirth.day"),
+    '_label -> Messages("date.fields.day"),
+    '_labelClass -> "form-group form-group-day",
+    '_inputClass -> "form-control input--xsmall",
+    '_emptyValueText -> " ",
+    '_hideErrors -> " ",
+    '_hideBar -> " "
     )
+    @input(
+    memberDobForm("dateOfBirth.month"),
+    '_label -> Messages("date.fields.month"),
+    '_labelClass -> "form-group form-group-month",
+    '_inputClass -> "form-control input--xsmall",
+    '_emptyValueText -> " ",
+    '_hideErrors -> " ",
+    '_hideBar -> " "
+    )
+    @input(
+    memberDobForm("dateOfBirth.year"),
+    '_label -> Messages("date.fields.year"),
+    '_labelClass -> "form-group form-group-year",
+    '_inputClass -> "form-control input--xsmall",
+    '_emptyValueText -> " ",
+    '_hideErrors -> " ",
+    '_hideBar -> " "
+    )
+
 </fieldset>
+</div>
+
+
 <button class="button" type="submit" id="continue"
         data-journey-click="button - click:What is their DOB?:Continue@if(edit){ and submit}">
     @messages("continue")


### PR DESCRIPTION
# DDCE-1446

The DAC review noted that there were duplicate fieldset and legend elements on this page. There were being brought in by the play-ui helper that as being used, so I have swapped to a lower-level helper (the input) that doesn't have those elements present. Also added aria-describedby as requested n the ticket.

Tested using MacOS VoiceOver and it seems good, although the issue was originally noted with JAWS & NVDA which are windows only so I cannot confirm these. 

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
