### PR TITLE
DDCE-6356: Update to add timed out page indicating the user has been signed out

### DIFF
--- a/a11y/FrontendAccessibilitySpec.scala
+++ b/a11y/FrontendAccessibilitySpec.scala
@@ -50,6 +50,7 @@ class FrontendAccessibilitySpec
       sorry_you_need_to_start_again                                 => render(sorry_you_need_to_start_again)
     case unauthorised: unauthorised                                 => render(unauthorised)
     case upload_result: upload_result => render(upload_result)
+    case signed_out: signed_out => render(signed_out)
   }
 
   runAccessibilityTests()

--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -43,6 +43,7 @@ class ApplicationConfig @Inject()(config: ServicesConfig){
 	lazy val reportAProblemPartialUrl: String = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
 	lazy val reportAProblemNonJSUrl: String = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
 	lazy val signOutAndContinueUrl: String = s"$signOutBaseUrl$continueCallback"
+	lazy val timedOutUrl: String = "/relief-at-source/signed-out"
 	lazy val loginCallback: String = config.getConfString("gg-urls.login-callback.url","/relief-at-source/")
 	lazy val fileDeletionUrl: String = config.getConfString("file-deletion-url","/ras-api/file/remove/")
 	lazy val rasApiResidencyStatusEndpoint: String = loadConfig("residency-status-url")

--- a/app/controllers/SignedOutController.scala
+++ b/app/controllers/SignedOutController.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.ApplicationConfig
+import play.api.Logging
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class SignedOutController @Inject()(val authConnector: DefaultAuthConnector,
+                                    val mcc: MessagesControllerComponents,
+                                    implicit val appConfig: ApplicationConfig,
+                                    signedOutView: views.html.signed_out
+                                   ) extends FrontendController(mcc) with RasController with Logging {
+
+  implicit val ec: ExecutionContext = mcc.executionContext
+
+  def signedOut: Action[AnyContent] = Action.async {
+    implicit request =>
+      isAuthorised().flatMap {
+        case Right(_) => Future.successful(
+          Ok(signedOutView())
+        )
+        case Left(resp) =>
+          logger.warn("[SignedOutController][signedOut] User is unauthenticated")
+          resp
+      }
+  }
+}

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -27,16 +27,18 @@
     hmrcTimeoutDialogHelper: HmrcTimeoutDialogHelper
 )
 
-@(pageTitle: String, beforeContentHtml: Option[Html] = None, showUrBanner: Boolean = false, scriptElem: Option[Html] = None)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages, appConfig: ApplicationConfig)
+@(pageTitle: String, beforeContentHtml: Option[Html] = None, showUrBanner: Boolean = false, scriptElem: Option[Html] = None, turnOnSignOutDialogHelper: Boolean = true)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages, appConfig: ApplicationConfig)
 
 @head = {
     <meta name="format-detection" content="telephone=no" />
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/ras.css")'/>
-    @hmrcTimeoutDialogHelper(
-        signOutUrl = appConfig.signOutAndContinueUrl,
-        timeout = Some(appConfig.timeOutSeconds),
-        countdown = Some(appConfig.timeOutCountDownSeconds)
-    )
+    @if(turnOnSignOutDialogHelper){
+        @hmrcTimeoutDialogHelper(
+            signOutUrl = appConfig.timedOutUrl,
+            timeout = Some(appConfig.timeOutSeconds),
+            countdown = Some(appConfig.timeOutCountDownSeconds)
+        )
+    }
 }
 
 @content = {

--- a/app/views/signed_out.scala.html
+++ b/app/views/signed_out.scala.html
@@ -1,0 +1,32 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.ApplicationConfig
+@this(govuk_wrapper: views.html.govuk_wrapper, govukButton: GovukButton)
+@()(implicit request: RequestHeader, messages: Messages, appConfig: ApplicationConfig)
+
+@govuk_wrapper(pageTitle = messages("sign.out.page.title"), turnOnSignOutDialogHelper = false){
+    <h1 id="page-header" class="govuk-heading-l">@messages("sign.out.page.header")</h1>
+    @govukButton(
+        Button(
+            inputType = Some("submit"),
+            classes = "button",
+            content = Text(messages("sign.out.button")),
+            href = Some(appConfig.signOutAndContinueUrl),
+            attributes = Map("id" -> "sign in")
+        )
+    )
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -45,3 +45,5 @@ GET         /check-another-member/:target                                       
 GET         /keep-alive                                                         controllers.SessionController.keepAlive
 
 GET         /logout                                                             controllers.LogoutController.logout
+
+GET         /signed-out                                                         controllers.SignedOutController.signedOut

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -67,7 +67,7 @@ microservice {
 	}
 
 	sessionTimeout {
-		timeoutSeconds=780
+		timeoutSeconds=900
 		time-out-countdown-seconds=120
 		enableRefresh = true
 	}

--- a/conf/messages
+++ b/conf/messages
@@ -219,7 +219,7 @@ ras.timeoutDialog.p1 = For security reasons, you will be signed out of this serv
 ras.timeoutDialog.signout= Sign out
 
 ##signoutDialog
-sign.out.page.title = For your security, we signed you out
+sign.out.page.title = For your security, we signed you out – Relief At Source – GOV.UK
 sign.out.button = Sign in
 
 ###### WDYWTDP ######################################################################################

--- a/conf/messages
+++ b/conf/messages
@@ -38,6 +38,7 @@ results.not.available.yet.page.header = The results file is not available yet
 file.not.available.page.header = This file is not available
 unauthorised.page.header = You cannot use these sign in details
 file.ready.page.header = The last file you uploaded is ready
+sign.out.page.header = For your security, we signed you out
 
 ###### SUB-HEADERS #################################################################################
 
@@ -216,6 +217,10 @@ ras.timeoutDialog.minute= minute
 ras.timeoutDialog.button= Stay signed in
 ras.timeoutDialog.p1 = For security reasons, you will be signed out of this service in:
 ras.timeoutDialog.signout= Sign out
+
+##signoutDialog
+sign.out.page.title = For your security, we signed you out
+sign.out.button = Sign in
 
 ###### WDYWTDP ######################################################################################
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,8 +1,8 @@
 import sbt.*
 
 object AppDependencies {
-  val bootstrapVersion = "9.5.0"
-  val hmrcMongoVersion = "2.0.0"
+  val bootstrapVersion = "9.11.0"
+  val hmrcMongoVersion = "2.5.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += "HMRC-open-artefacts-maven2" at "https://open.artefacts.tax.service
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"            % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"        % "2.5.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"        % "2.6.0")
 addSbtPlugin("org.scalastyle"       %% "scalastyle-sbt-plugin"    % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
-addSbtPlugin("org.playframework"    % "sbt-plugin"                % "3.0.5")
+addSbtPlugin("org.playframework"    % "sbt-plugin"                % "3.0.6")
 addSbtPlugin("org.scoverage"        %% "sbt-scoverage"            % "2.0.12")
 addSbtPlugin("com.timushev.sbt"     % "sbt-updates"               % "0.6.4")
 addSbtPlugin("io.github.irundaia"   % "sbt-sassify"               % "1.5.2")

--- a/test/utils/RasTestHelper.scala
+++ b/test/utils/RasTestHelper.scala
@@ -137,4 +137,5 @@ trait RasTestHelper extends MockitoSugar with MongoSupport {  this: Suite =>
 	val unauthorisedView: unauthorised = fakeApplication.injector.instanceOf[unauthorised]
 	val uploadResultView: upload_result = fakeApplication.injector.instanceOf[upload_result]
 	val startAtStartView: sorry_you_need_to_start_again = fakeApplication.injector.instanceOf[sorry_you_need_to_start_again]
+	val signedOutView: signed_out = fakeApplication.injector.instanceOf[signed_out]
 }

--- a/test/views/SignedOutViewSpec.scala
+++ b/test/views/SignedOutViewSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import org.jsoup.Jsoup
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.i18n.Messages
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout}
+import utils.RasTestHelper
+
+class SignedOutViewSpec extends AnyWordSpec with RasTestHelper {
+
+  "signed out page" must {
+
+    "contain correct title and sign in button should have correct href" in {
+      val result = signedOutView()(fakeRequest, testMessages, mockAppConfig)
+      val doc = Jsoup.parse(contentAsString(result))
+      doc.title shouldBe Messages("sign.out.page.title")
+      doc.getElementById("sign in").attr("href") shouldBe mockAppConfig.signOutAndContinueUrl
+    }
+  }
+}


### PR DESCRIPTION
- Add sign out page for users whos session has timed out
- For local testing its useful to set `sessionTimeout.timeoutSeconds` to a small number e.g. `10` in `application.conf` to make how long you have to wait to see the new page shorter
- PR to update app-config-base [here](https://github.com/hmrc/app-config-base/pull/11802)